### PR TITLE
Fix IValidationRule import path

### DIFF
--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -3,7 +3,7 @@ import MinValidationRule from "./MinValidationRule.ts";
 import MaxValidationRule from "./MaxValidationRule.ts";
 import EmailValidationRule from "./EmailValidationRule.ts";
 import DomainValidationRule from "./DomainValidationRule.ts";
-import IValidationRule  from "./IValidationRule.js";
+import IValidationRule  from "./IValidationRule.ts";
 import RegexValidationRule from "@/rules/RegexValidationRule.ts";
 
 export default {


### PR DESCRIPTION
## Summary
- use `.ts` extension for IValidationRule import

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff494d10c8326a676563aade2a038