### PR TITLE
Add Vue useValidation composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,17 @@ console.log(result.summary)     // full list of errors
 ```
 
 Custom rules like `MatchFieldValidationRule` can access other fields by name or via a callback, making dependent validations straightforward.
+
+## Vue Composable Helper
+
+For projects using Vue's Composition API, the `useValidation` composable keeps validation state reactive.
+
+```ts
+import { ref } from 'vue'
+import { useValidation } from 'oop-validator'
+
+const username = ref('')
+const { errors, isValid } = useValidation(username, ['required', { rule: 'min', params: { length: 3 } }])
+
+// `errors` and `isValid` update automatically when `username` changes
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export { default as RegexValidationRule } from "./rules/RegexValidationRule.ts";
 
 export { default as FormValidationEngine } from "./form/FormValidationEngine.ts";
 export { default as MatchFieldValidationRule } from "./rules/MatchFieldValidationRule.ts";
+export { default as useValidation } from "./vue/useValidation.ts";

--- a/src/vue/useValidation.test.ts
+++ b/src/vue/useValidation.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { useValidation } from '../index'
+
+describe('useValidation', () => {
+  it('reactively validates values', async () => {
+    const value = ref('')
+    const { isValid, errors } = useValidation(value, ['required'])
+
+    await nextTick()
+    expect(isValid.value).toBe(false)
+    expect(errors.value.length).toBe(1)
+
+    value.value = 'ok'
+    await nextTick()
+
+    expect(isValid.value).toBe(true)
+    expect(errors.value.length).toBe(0)
+  })
+})

--- a/src/vue/useValidation.ts
+++ b/src/vue/useValidation.ts
@@ -1,0 +1,41 @@
+import { Ref, ref, watch } from 'vue'
+import ValidationEngine from '../rules/ValidationEngine'
+import IValidationRule from '../rules/IValidationRule'
+
+export type UseValidationRule = string | { rule: string; params: any; message?: string } | IValidationRule
+
+export interface UseValidationResult {
+  errors: Ref<string[]>
+  isValid: Ref<boolean>
+  validate: (value?: any) => boolean
+}
+
+export default function useValidation(
+  value: Ref<any>,
+  rules: UseValidationRule[]
+): UseValidationResult {
+  const engine = new ValidationEngine(rules)
+  const errors = ref<string[]>([])
+  const isValid = ref(true)
+
+  const validate = (val: any = value.value): boolean => {
+    const result = engine.validateValue(val)
+    errors.value = result.errors
+    isValid.value = result.isValid
+    return result.isValid
+  }
+
+  watch(
+    value,
+    (val) => {
+      validate(val)
+    },
+    { immediate: true }
+  )
+
+  return {
+    errors,
+    isValid,
+    validate,
+  }
+}


### PR DESCRIPTION
## Summary
- create `useValidation` composable in `src/vue`
- export the composable from the main entry
- document the helper in README
- cover new helper with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684022d2aa108326b496a0d6ec1fcd9f