### PR TITLE
fix: clean up validation rules when a field is removed by v-if

### DIFF
--- a/src/integration/conditional-fields.test.ts
+++ b/src/integration/conditional-fields.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+//
+// Regression: a field rendered behind v-if used to keep its rules registered
+// after it was removed. Vue detaches the element before running a directive's
+// `unmounted` hook, so `el.closest('form')` was already null and the cleanup
+// silently did nothing — leaving the form permanently invalid, and v-submit
+// refusing to call its handler with no error message on screen (the element
+// that would have shown it is gone).
+import { describe, it, expect } from 'vitest';
+import { createApp, reactive, ref, nextTick } from 'vue';
+import { VueValidationPlugin } from '../vue/directives/install';
+import { useForm } from '../vue/useForm';
+import { formRegistry } from '../vue/directives/registry';
+
+function mountConditionalForm() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const showDate = ref(true);
+  const formData = reactive({ date: null as string | null, name: 'someone' });
+  let form: any;
+
+  const app = createApp({
+    setup() {
+      form = useForm('conditionalForm', formData);
+      return { form, showDate, formData };
+    },
+    template: `
+      <form name="conditionalForm">
+        <input v-if="showDate" type="text" name="date" v-model="formData.date" v-required />
+        <input v-else type="text" name="name" v-model="formData.name" />
+      </form>
+    `,
+  });
+  app.use(VueValidationPlugin);
+  app.mount(container);
+
+  formRegistry.set(container.querySelector('form') as HTMLFormElement, form);
+
+  return {
+    showDate,
+    getForm: () => form,
+    cleanup: () => {
+      app.unmount();
+      container.remove();
+    },
+  };
+}
+
+describe('Conditionally rendered fields', () => {
+  it('drops rules of a required field once v-if removes it', async () => {
+    const { showDate, getForm, cleanup } = mountConditionalForm();
+    await nextTick();
+
+    getForm().validate();
+    expect(getForm().$valid.value).toBe(false); // date is empty and required
+
+    showDate.value = false;
+    await nextTick();
+    await nextTick();
+
+    getForm().validate();
+    expect(Object.keys(getForm().fields.value)).not.toContain('date');
+    expect(getForm().$valid.value).toBe(true);
+
+    cleanup();
+  });
+
+  it('re-registers the rules when v-if brings the field back', async () => {
+    const { showDate, getForm, cleanup } = mountConditionalForm();
+    await nextTick();
+
+    showDate.value = false;
+    await nextTick();
+    await nextTick();
+
+    showDate.value = true;
+    await nextTick();
+    await nextTick();
+
+    getForm().validate();
+    expect(getForm().$valid.value).toBe(false);
+    expect(getForm().$error.value.date).toEqual({ required: true });
+
+    cleanup();
+  });
+});

--- a/src/vue/directives/registry.ts
+++ b/src/vue/directives/registry.ts
@@ -75,12 +75,28 @@ export function getFormInstance(el: HTMLElement): FormInstance | null {
   return instance
 }
 
+// The form an element's directives bound to at mount time.
+// Vue removes an element from the DOM *before* running a directive's `unmounted`
+// hook, so `el.closest('form')` is null by then and the lookup above cannot find
+// the form to clean up against. Remembering the instance keeps unmount cleanup
+// working for conditionally rendered fields (v-if / v-show swaps).
+const boundForms = new WeakMap<HTMLElement, FormInstance>()
+
+// Helper: get the form an element is bound to, usable after the element has been
+// detached. Falls back to the DOM lookup for elements that never mounted a
+// field-controller directive.
+export function getBoundFormInstance(el: HTMLElement): FormInstance | null {
+  return boundForms.get(el) ?? getFormInstance(el)
+}
+
 // Helper: ensure a field controller exists for an element
 export function ensureFieldController(
   el: HTMLElement,
   form: FormInstance,
   fieldName: string,
 ): FieldController {
+  boundForms.set(el, form)
+
   let controller = fieldControllers.get(el)
 
   if (!controller) {
@@ -153,6 +169,7 @@ export function releaseFieldController(el: HTMLElement, form: FormInstance): voi
     controller.stopWatcher?.()
 
     fieldControllers.delete(el)
+    boundForms.delete(el)
     form.unregisterField(controller.fieldName)
   }
 }

--- a/src/vue/directives/vMax.ts
+++ b/src/vue/directives/vMax.ts
@@ -1,6 +1,6 @@
 import type { Directive, DirectiveBinding } from 'vue'
 import NumericMaxValidationRule from '../../rules/NumericMaxValidationRule'
-import { getFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
+import { getFormInstance, getBoundFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
 
 interface CleanupData {
   fieldName: string
@@ -57,7 +57,7 @@ export const vMax: Directive<HTMLElement, number> = {
     const cleanup = cleanupMap.get(el)
     if (!cleanup) return
 
-    const form = getFormInstance(el)
+    const form = getBoundFormInstance(el)
     if (form) {
       form.unregisterRule(cleanup.fieldName, 'max')
       releaseFieldController(el, form)

--- a/src/vue/directives/vMaxlength.ts
+++ b/src/vue/directives/vMaxlength.ts
@@ -1,6 +1,6 @@
 import type { Directive, DirectiveBinding } from 'vue'
 import MaxValidationRule from '../../rules/MaxValidationRule'
-import { getFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
+import { getFormInstance, getBoundFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
 
 interface CleanupData {
   fieldName: string
@@ -59,7 +59,7 @@ export const vMaxlength: Directive<HTMLElement, number> = {
     const cleanup = cleanupMap.get(el)
     if (!cleanup) return
 
-    const form = getFormInstance(el)
+    const form = getBoundFormInstance(el)
     if (form) {
       form.unregisterRule(cleanup.fieldName, 'maxlength')
       releaseFieldController(el, form)

--- a/src/vue/directives/vMin.ts
+++ b/src/vue/directives/vMin.ts
@@ -1,6 +1,6 @@
 import type { Directive, DirectiveBinding } from 'vue'
 import NumericMinValidationRule from '../../rules/NumericMinValidationRule'
-import { getFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
+import { getFormInstance, getBoundFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
 
 interface CleanupData {
   fieldName: string
@@ -57,7 +57,7 @@ export const vMin: Directive<HTMLElement, number> = {
     const cleanup = cleanupMap.get(el)
     if (!cleanup) return
 
-    const form = getFormInstance(el)
+    const form = getBoundFormInstance(el)
     if (form) {
       form.unregisterRule(cleanup.fieldName, 'min')
       releaseFieldController(el, form)

--- a/src/vue/directives/vMinlength.ts
+++ b/src/vue/directives/vMinlength.ts
@@ -1,6 +1,6 @@
 import type { Directive, DirectiveBinding } from 'vue'
 import MinValidationRule from '../../rules/MinValidationRule'
-import { getFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
+import { getFormInstance, getBoundFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
 
 interface CleanupData {
   fieldName: string
@@ -59,7 +59,7 @@ export const vMinlength: Directive<HTMLElement, number> = {
     const cleanup = cleanupMap.get(el)
     if (!cleanup) return
 
-    const form = getFormInstance(el)
+    const form = getBoundFormInstance(el)
     if (form) {
       form.unregisterRule(cleanup.fieldName, 'minlength')
       releaseFieldController(el, form)

--- a/src/vue/directives/vPattern.ts
+++ b/src/vue/directives/vPattern.ts
@@ -1,6 +1,6 @@
 import type { Directive, DirectiveBinding } from 'vue'
 import RegexValidationRule from '../../rules/RegexValidationRule'
-import { getFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
+import { getFormInstance, getBoundFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
 
 interface CleanupData {
   fieldName: string
@@ -75,7 +75,7 @@ export const vPattern: Directive<HTMLElement, string | RegExp> = {
     const cleanup = cleanupMap.get(el)
     if (!cleanup) return
 
-    const form = getFormInstance(el)
+    const form = getBoundFormInstance(el)
     if (form) {
       form.unregisterRule(cleanup.fieldName, 'pattern')
       releaseFieldController(el, form)

--- a/src/vue/directives/vRequired.ts
+++ b/src/vue/directives/vRequired.ts
@@ -1,6 +1,6 @@
 import type { Directive, DirectiveBinding } from 'vue'
 import RequiredValidationRule from '../../rules/RequiredValidationRule'
-import { getFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
+import { getFormInstance, getBoundFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
 
 interface CleanupData {
   fieldName: string
@@ -66,7 +66,7 @@ export const vRequired: Directive<HTMLElement, boolean | undefined> = {
     const cleanup = cleanupMap.get(el)
     if (!cleanup) return
 
-    const form = getFormInstance(el)
+    const form = getBoundFormInstance(el)
     if (form) {
       form.unregisterRule(cleanup.fieldName, cleanup.ruleKey)
       releaseFieldController(el, form)

--- a/src/vue/directives/vType.ts
+++ b/src/vue/directives/vType.ts
@@ -3,7 +3,7 @@ import EmailValidationRule from '../../rules/EmailValidationRule'
 import UrlValidationRule from '../../rules/UrlValidationRule'
 import DateValidationRule from '../../rules/DateValidationRule'
 import NumberValidationRule from '../../rules/NumberValidationRule'
-import { getFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
+import { getFormInstance, getBoundFormInstance, ensureFieldController, releaseFieldController, updateCssClasses } from './registry'
 
 interface CleanupData {
   fieldName: string
@@ -101,7 +101,7 @@ export const vType: Directive<HTMLElement, string | undefined> = {
     const cleanup = cleanupMap.get(el)
     if (!cleanup) return
 
-    const form = getFormInstance(el)
+    const form = getBoundFormInstance(el)
     if (form) {
       if (cleanup.typeKey) {
         form.unregisterRule(cleanup.fieldName, cleanup.typeKey)


### PR DESCRIPTION
## Problem

A field rendered behind `v-if` keeps its validation rules registered after it is removed.

Vue detaches an element **before** running a directive's `unmounted` hook, so `el.closest('form')` is already `null` by then. `getFormInstance(el)` returns `null`, the `if (form)` guard skips, and neither `unregisterRule` nor `releaseFieldController` ever runs.

The consequence is hard to debug in an app: the form stays permanently invalid because of a field nobody can see, so `v-submit` silently refuses to call its handler — and no error message renders, since the element that would have shown it is gone. It looks like a dead button.

Real case: a logs screen whose filter inputs depend on the selected type. Pick a date-type filter (required date), switch to a type that filters by username, hit the submit button — nothing happens, no message.

## Fix

Remember the form instance per element at mount time (`ensureFieldController`, which every field directive already calls) and look it up from there during unmount, instead of walking a DOM the element has already left. `getBoundFormInstance()` falls back to the existing DOM lookup, so nothing else changes.

Applied to the directives that share the same `unmounted` shape: `v-required`, `v-minlength`, `v-maxlength`, `v-pattern`, `v-min`, `v-max`, `v-type`.

## Tests

`src/integration/conditional-fields.test.ts` covers both directions — rules dropped when `v-if` removes the field, and re-registered when it comes back. The first case fails on `master` (`expected [ 'date' ] to not include 'date'`) and passes with this change.

Full suite: 318 passing.

Note: this is a distinct issue from v1.1.3's conditionally-rendered `<form>` support — that one is about the form element mounting late, this one about a field unmounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)